### PR TITLE
added epicurus quote

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1302,5 +1302,9 @@
    {  
       "text":"I learned not to worry so much about the outcome, but to concentrate on the step I was on and to try to do it as perfectly as I could when I was doing it.",
       "from":"Steve Wozniak, Co-Founder of Apple"
+   },
+   {
+      "text":"Nothing is enough for the man to whom enough is too little.",
+      "from":"Epicurus"
    }
 ]


### PR DESCRIPTION
A quote by Stoic philosopher Epicurus. 

  {
      "text":"Nothing is enough for the man to whom enough is too little.",
      "from":"Epicurus"
   }

https://georgevrakas.com/favourite-quotations/practical-philosophy/epicurus-tetrafarmakos-an-interpretation/