### PR TITLE
Fix “I never think of the future”

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -48,8 +48,8 @@
       "from":"Marcia Wieder"
    },
    {  
-      "text":"I never think of the future",
-      "from":"it comes soon enough."
+      "text":"I never think of the future. It comes soon enough.",
+      "from":"Albert Einstein"
    },
    {  
       "text":"Don't waste your life in doubts and fears: Spend yourself on the work before you, well assured that the right performance of this hour's duties will be the best preparation for the hours or ages that follow it.",


### PR DESCRIPTION
The `from` field is erroneously part of the quote and no one is credited with saying this.

It should be credited to Albert Einstein according to this source: https://quoteinvestigator.com/2013/07/23/future-soon/