### PR TITLE
add Simon Sinek quote

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1302,5 +1302,9 @@
    {  
       "text":"I learned not to worry so much about the outcome, but to concentrate on the step I was on and to try to do it as perfectly as I could when I was doing it.",
       "from":"Steve Wozniak, Co-Founder of Apple"
+   },
+   {
+      "text": "People don’t buy what you do; they buy why you do it. And what you do simply proves what you believe.",
+      "from": "Simon Sinek, Leader and Bookwriter"
    }
 ]


### PR DESCRIPTION
Quote added People don’t buy what you do; they buy why you do it. And what you do simply proves what you believe. – Simon Sinek.
Source: https://www.goalcast.com/2017/08/29/top-simon-sinek-quotes-hard-truths-success/