### PR TITLE
add: new inspirational quote

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1302,5 +1302,9 @@
    {  
       "text":"I learned not to worry so much about the outcome, but to concentrate on the step I was on and to try to do it as perfectly as I could when I was doing it.",
       "from":"Steve Wozniak, Co-Founder of Apple"
+   },
+   {  
+      "text":"There are only two industries that call their customers 'users': illegal drugs and software.",
+      "from":"Edward Tufte, American statistician"
    }
 ]


### PR DESCRIPTION
Source: https://www.reddit.com/r/quotes/comments/dd0kov/there_are_only_two_industries_that_refer_to_their/

Added quote: There are only two industries that call their customers ‘users’: illegal drugs and software.
From: Edward Tufte, American statistician

@vinitshahdeo #4 