### PR TITLE
Fix format & attribution of “if you have a competitive advantage, don’t compete”

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -948,8 +948,8 @@
       "from":"Tony Robbins"
    },
    {  
-      "text":"If you don’t have a competitive advantage",
-      "from":"don’t compete.”"
+      "text":"If you don’t have a competitive advantage, don’t compete.",
+      "from":"Jack Welch"
    },
    {  
       "text":"You were born to win, but to be a winner, you must plan to win, prepare to win, and expect to win.",


### PR DESCRIPTION
The quote was previously badly formatted, badly cut in two:

- the first half of it (_“If you don’t have a competitive advantage”_) was in `text`;
- and the second half (_“don’t compete”_) was in the `from` field.

As for proper attribution, the quote seems to be from from Jack Welch:

> Jack Welch, the chairman and CEO of General Electric between 1981 and 2001, 
> told Fortune magazine of March 27, 1989 his six rules, one of which was:
>
>     “If you don’t have a competitive advantage, don’t compete.”
>
> The rule has made many lists of business quotations.
— https://www.barrypopik.com/index.php/new_york_city/entry/if_you_dont_have_a_competitive_advantage_dont_compete

   
(Other links from Google seems to ± agree with this.)