### PR TITLE
add new quote

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -3,6 +3,10 @@
       "text":"The only people who never fail are those who never try.",
       "from":"Ilka Chase"
    },
+   {
+      "text":"That which does not kill us makes us stronger.",
+      "from":"Friedrich Nietzche, German Philosopher"
+   },
    {  
       "text":"Failure is just another way to learn how to do something right.",
       "from":"Marian Wright Edelman"


### PR DESCRIPTION
https://www.psychologytoday.com/us/blog/insight-therapy/201008/what-doesnt-kill-you-makes-you-weaker

Friedrich Nietzsche, the German philosopher, famously said: "**That which does not kill us makes us stronger.**" This notion found life beyond Nietzsche's—which is ironic, his having been rather short and miserable—and it continues to resonate within American culture.